### PR TITLE
Include articles

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -11,3 +11,4 @@
 ^docs$
 ^pkgdown$
 ^\.github$
+^vignettes/articles$

--- a/.github/workflows/rworkflows.yml
+++ b/.github/workflows/rworkflows.yml
@@ -6,6 +6,7 @@ name: rworkflows
       - main
       - devel
       - RELEASE_**
+      - include-articles
   pull_request:
     branches:
       - master
@@ -48,7 +49,7 @@ jobs:
           run_vignettes: ${{ true }}
           has_testthat: ${{ true }}
           run_covr: ${{ true }}
-          run_pkgdown: ${{ env.DEPLOY_PKGDOWN }}
+          run_pkgdown: ${{ true }}
           has_runit: ${{ false }}
           has_latex: ${{ false }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/vignettes/articles/Non-targeted_metabolomics_feature_prioritization.Rmd
+++ b/vignettes/articles/Non-targeted_metabolomics_feature_prioritization.Rmd
@@ -1,0 +1,174 @@
+---
+title: "Non-targeted metabolomics feature prioritization"
+author: "Anton Klåvus, Vilhelm Suksi"
+date: "`r Sys.Date()`"
+output:
+  BiocStyle::html_document:
+    toc: true
+    toc_depth: 2
+vignette: >
+  %\VignetteIndexEntry{Non-targeted metabolomics feature prioritization}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+bibliography: references.bib
+biblio-style: apalike
+---
+
+The statistics functionality in `notameStats` aims to identify interesting 
+features across study groups. See the project example vignette in the notame 
+package and [notame website reference index](https://hanhineva-lab.github.io/
+notame/reference/index.html) for listing of functions. Similar functionality is 
+available in several packages.
+
+Unless otherwise stated, all functions return separate data frames or other 
+objects with the results. These can be then added to the object feature data 
+using ```join_rowData(object, results)```. The reason for not adding these to 
+the objects automatically is that most of the functions return excess 
+information that is not always worth saving. We encourage you to choose which 
+information is important to you.
+
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  comment = "##",
+  message = FALSE
+)
+```
+
+# Installation
+
+To install `notameStats`, install `BiocManager` first, if it is not installed.
+Afterwards use the `install` function from `BiocManager` and load `notameStats`.
+
+```{r install, eval=FALSE}
+if (!requireNamespace("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
+BiocManager::install("notameStats")
+```
+
+```{r, message = FALSE}
+library(notame)
+library(notameViz)
+library(notameStats)
+
+ppath <- tempdir()
+init_log(log_file = file.path(ppath, "log.txt"))
+
+data(hilic_neg_sample, package = "notame")
+data(toy_notame_set, package = "notame")
+```
+
+# Univariate functions
+
+## Summary statistics and effect sizes
+
+It is straightforward to provide summary statistics and effect sizes for all 
+features:
+
+```{r}
+toy_notame_set <- mark_nas(toy_notame_set, value = 0)
+
+# Impute missing values, required especially for multivariate methods
+toy_notame_set <- notame::impute_rf(toy_notame_set)
+
+sum_stats <- summary_statistics(toy_notame_set, grouping_cols = "Group")
+toy_notame_set <- notame::join_rowData(toy_notame_set, sum_stats)
+
+d_results <- cohens_d(toy_notame_set, group = "Group")
+toy_notame_set <- notame::join_rowData(toy_notame_set, d_results)
+
+fc <- fold_change(toy_notame_set, group = "Group")
+toy_notame_set <- notame::join_rowData(toy_notame_set, fc)
+
+colnames(rowData(toy_notame_set))
+```
+
+## Univariate tests
+
+These functions perform univariate hypothesis tests for each feature, report 
+relevant statistics and correct the p-values using FDR correction. For 
+features, where the model fails for some reason, all statistics are recorded as 
+NA. **NOTE** setting ```all_features = FALSE``` does not prevent the tests on 
+the flagged compounds, but only affects p-value correction, where flagged 
+features are not included in the correction and thus do not have an FDR-
+corrected p-value. To prevent the testing of flagged features altogether, use 
+`notame::drop_flagged` before the tests.
+
+Most of the univariate statistical test functions in this package use the 
+formula interface, where the formula is provided as a character, with one 
+special condition: the word "Feature" will get replaced at each iteration by 
+the corresponding feature name. So for example, when testing if any of the 
+features predict the difference between study groups, the formula would be: 
+"Group ~ Feature". Or, when testing if group and time point affect metabolite 
+levels, the formula could be "Feature ~ Group + Time + Group:Time", with the 
+last term being an interaction term ("Feature ~ Group * Time" is equivalent).
+
+```{r}
+
+toy_notame_set <- notame::flag_quality(toy_notame_set)
+toy_notame_set <- notame::drop_qcs(toy_notame_set)
+
+lm_results <- perform_lm(toy_notame_set, 
+  formula_char = "Feature ~ Group + Time")
+
+```
+
+Most of the functions allow you to pass extra arguments to the underlying 
+functions performing the actual tests, so you can set custom contrasts etc.
+
+Functions not using the formula interface include correlation tests between 
+molecular features and/or sample information variable 
+(`perform_correlation_tests()`) and area under curve computation 
+(`perform_auc()`).
+
+# Multivariate analysis
+
+## MUVR
+
+notame provides a wrapper for the MUVR analysis (Multivariate methods with 
+Unbiased Variable selection in R, [shi2019variable] using the MUVR2 package. 
+MUVR2 allows fitting both RF and PLS models with clever variable selection for 
+both finding a minimal subset of features that achieves a good performance AND 
+for finding all relevant features. There is also a set of useful visualizations 
+in `MUVR2`.
+  
+```{r}
+# nRep = 2 for quick example
+pls_model <- muvr_analysis(toy_notame_set, 
+  y = "Injection_order", nRep = 2, method = "PLS")
+  
+class(pls_model)
+
+```
+
+## Random forest
+
+For random forest models, we also use the `randomForest` package. We also 
+include a wrapper for getting feature importance.
+
+```{r}
+rf <- fit_rf(toy_notame_set, y = "Group")
+
+class(rf)
+
+head(importance_rf(rf))
+```
+
+## PLS(-DA)
+
+There are also wrappers for PLS(-DA) functions from the mixOmics package.
+
+```{r}
+pls_res <- mixomics_pls(toy_notame_set, y = "Injection_order", ncomp = 3)
+
+class(pls_res)
+```
+
+# Session information
+
+```{r, echo = FALSE, results = 'markup'}
+sessionInfo()
+```
+
+# References
+
+

--- a/vignettes/articles/Non_targeted_metabolomics_visualization.Rmd
+++ b/vignettes/articles/Non_targeted_metabolomics_visualization.Rmd
@@ -1,0 +1,128 @@
+---
+title: "Non-targeted metabolomics visualization"
+author: "Anton Klåvus, Vilhelm Suksi"
+date: "`r Sys.Date()`"
+output:
+  BiocStyle::html_document:
+    toc: true
+    toc_depth: 2
+vignette: >
+  %\VignetteIndexEntry{Non-targeted metabolomics visualization}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+bibliography: references.bib
+biblio-style: apalike
+---
+
+The visualizations in `notameViz` can be used to monitor the processing and 
+explore the data, inspect individual features as well as plot results. Please 
+see the [notame website](https://
+hanhineva-lab.github.io/notame/) and protocol article for more information 
+[@notame]. Similar functionality is available in `miaViz` and `scater` 
+packages.
+
+# Installation
+
+To install `notameViz`, install `BiocManager` first, if it is not installed.
+Afterwards use the `install` function from `BiocManager` and load `notameViz`.
+
+```{r install, eval=FALSE}
+if (!requireNamespace("BiocManager", quietly = TRUE))
+    install.packages("BiocManager")
+BiocManager::install("notameViz")
+```
+
+```{r setup, message = FALSE}
+library(notame)
+library(notameViz)
+library(notameStats)
+
+ppath <- tempdir()
+init_log(log_file = file.path(ppath, "log.txt"))
+
+data(hilic_neg_sample, package = "notame")
+data(toy_notame_set, package = "notame")
+```
+
+# Preprocessing visualizations
+
+Preprocessing visualizations are used to monitor preprocessing such as drift 
+correction and explore the data. Preprocessing visualizations return ggplot2 
+objects. Preprocessing is performed separately for each mode. 
+
+
+```{r}
+plot_sample_boxplots(hilic_neg_sample, order_by = "Group", fill_by = "Group")
+```
+
+The function `save_QC_plots` conveniently saves common visualizations after 
+each round of processing, ignoring flagged features by default. You can see 
+this in action in the project example vignette in the notame package. It also 
+allows you to merge all saved plots into one file by setting `merge = 
+TRUE`. NOTE that this requires you to install external tools. For Windows, 
+install [pdftk](https://www.pdflabs.com/tools/pdftk-the-pdf-toolkit/). For 
+linux, make sure `pdfunite` is installed.
+
+
+# Results visualizations
+
+Results visualizations return ggplot2 objects. Common visalizations include 
+effect heatmaps and volcano plots. Manhattan plots and cloud plots can be used 
+to relate results to biochemical features such as m/z and RT and are plotted 
+separately for each mode. To save these functions to a PDF file, use 
+`save_plot`.
+
+
+```{r}
+lm_results <- notameStats::perform_lm(notame::drop_qcs(toy_notame_set), 
+  formula_char = "Feature ~ Group")
+
+with_results <- notame::join_rowData(toy_notame_set, lm_results)
+
+p <- volcano_plot(with_results,
+  x = "GroupB.estimate", p = "GroupB.p.value", p_fdr = "GroupB.p.value_FDR")
+
+# save_plot(p, file = "volcano_plot.pdf")
+
+p 
+```
+
+# Feature-wise visualizations
+
+The following visualizations are applied to each feature and directly saved to 
+a PDF file, one page per feature. If `save = FALSE`, a list of plots is 
+returned: 
+
+```{r}
+beeswarm_list <- save_beeswarm_plots(toy_notame_set[1:10],
+  save = FALSE, x = "Group", color = "Group")
+  
+beeswarm_list[[1]]
+```
+
+# Color scales
+
+Color scales and other scales can be set separately for each function call, and 
+the defaults are set as options in the package. The scales are ggplot scales, 
+returned by e.g. `scale_color_x`. It is also possible to change the scales 
+globally for the complete project. To do this, use e.g. 
+`options("notame.color_scale_dis") <- scale_color_brewer(palette = 
+"Dark2")`. Below is a list of all the scales used in the package and their 
+default values (con = continuous, dis = discrete, div = diverging):
+
+- `notame.color_scale_con = ggplot2::scale_color_viridis_c()`
+- `notame.color_scale_dis = ggplot2::scale_color_brewer(palette = "Set1")`
+- `notame.fill_scale_con = ggplot2::scale_fill_viridis_c()`
+- `notame.fill_scale_dis = ggplot2::scale_fill_brewer(palette = "Set1")`
+- `notame.fill_scale_div = ggplot2::scale_fill_distiller(palette = "RdBu")`
+- `notame.shape_scale = ggplot2::scale_shape_manual(values = c(16, 17, 15, 3, 
+7, 8, 11, 13))`
+
+# Session information
+
+```{r, echo = FALSE, results = 'markup'}
+sessionInfo()
+```
+
+# References
+

--- a/vignettes/articles/project_template.Rmd
+++ b/vignettes/articles/project_template.Rmd
@@ -1,0 +1,125 @@
+---
+title: "Project template"
+author: "Anton Klåvus"
+date: "`r Sys.Date()`"
+output: rmarkdown::html_vignette
+vignette: >
+  %\VignetteIndexEntry{Project template}
+  %\VignetteEngine{knitr::rmarkdown}
+  %\VignetteEncoding{UTF-8}
+---
+  
+```{r setup, include = FALSE}
+knitr::opts_chunk$set(
+  collapse = TRUE,
+  comment = "#>"
+)
+```
+
+This vignette provides a template for a standard project, feel free to copy and paste.
+
+**NOTE:** I usually use the following folder structure for my projects:
+- **data** All the original data
+- **results** Results from statistics, preprocessed objects and figures
+  - **figures** A separate folder for the figures
+- **src** R scripts
+
+```{r, eval=FALSE}
+library(notame)
+library(notameViz)
+library(notameStats)
+
+# Define the project path
+ppath <- ""
+
+# Start logging
+init_log(log_file = paste0(ppath, "results/log_preprocessing.txt"))
+
+# Read data from Excel file
+object <- import_from_excel(
+  file = paste0(ppath, "data/"),
+  split_by = c("Column", "Ion_mode"))
+
+# Modify pheno_data if necessary (set factor levels etc.)
+
+# Create MetaboSet objects for each analytical mode
+objects <- list()
+for (mode in unique(rowData(object)$Split)) {
+  objects[[mode]] <- object[rowData(object)$Split == mode, ]
+}
+
+# Preprocessing by mode
+processed <- list()
+for (name in names(objects)) {
+  log_text(paste("Processing", name))
+  object <- objects[[name]]
+  log_text(paste(nrow(object), "features,", ncol(object), "samples\n"))
+  
+  # Mark NAs correctly and flag features with low detection
+  object <- mark_nas(object, 0)
+  detected <- flag_detection(object, qc_limit = 0.7, group_limit = 0.5)
+  
+  # Visualizations with original data
+  save_QC_plots(detected, prefix = paste0(ppath, "results/figures/",
+                name, "_ORIG"))
+  
+  # Drift correction with cubic spline in log space
+  corrected <- correct_drift(detected)
+  
+  # Flag low-quality features
+  flagged <- flag_quality(corrected)
+  
+  # Visualizations after quality control
+  save_QC_plots(flagged, prefix = paste0(ppath, "results/figures/", 
+                name, "_CLEANED"))
+  
+  # Remove QC samples before imputation
+  noqc <- drop_qcs(flagged)
+  
+  # Random forest imputation
+  # First impute qood quality features
+  set.seed(38)
+  imputed <- impute_rf(noqc)
+  # Then impute the rest of the features
+  imputed <- impute_rf(imputed, all_features = TRUE)
+  
+  # Save the processed object to list
+  processed[[name]] <- imputed  
+}
+
+# Merge analytical modes
+merged <- merge_notame_sets(processed)
+log_text(paste("Merged analytical modes together, the merged object has", nrow(merged), "features and", ncol(merged), "samples."))
+
+# Visualize complete dataset
+save_QC_plots(merged, prefix = paste0(ppath, "results/figures/FULL"))
+
+# Save processed objects, useful if you want to run statistics later
+save(processed, merged, file = paste0(ppath, "results/preprocessed.RData"))
+log_text("Saved preprocessed objects to results subfolder")
+
+# Statistics, naturally depends a lot on the project, but this is a general workflow
+lm_results <- perform_lm(merged, formula_char = "Feature ~ Group")
+
+# Add results to object
+# Remove intercept columns
+lm_results <- dplyr::select(lm_results, -contains("Intercept"))
+with_results <- join_rowData(merged, lm_results)
+
+# Write results to Excel
+write_to_excel(with_results, file = paste0(ppath, "results/results.xlsx"))
+
+# Draw plots of the most interesting features
+# Select interesting features based on statistical relevance
+# NOTE: just an example
+interesting <- lm_results[lm_results$GroupB.p.value_FDR< 0.05, ]$Feature_ID 
+
+# Save relevant visualizations of all the interesting features
+
+# Group box plots as an example
+save_group_boxplots(merged[interesting, ], x = "Group", color = "Group",
+                    file = paste0(ppath, "results/figures/group_boxplots.pdf"))
+
+# Finish logging and save session information
+finish_log()
+```

--- a/vignettes/articles/references.bib
+++ b/vignettes/articles/references.bib
@@ -1,0 +1,78 @@
+@article{kokla2019random,
+  title={Random forest-based imputation outperforms other methods for imputing LC-MS metabolomics data: a comparative study},
+  author={Kokla, Marietta and Virtanen, Jyrki and Kolehmainen, Marjukka and Paananen, Jussi and Hanhineva, Kati},
+  journal={BMC bioinformatics},
+  volume={20},
+  number={1},
+  pages={492},
+  year={2019},
+  publisher={Springer}
+}
+
+@article{notame,
+  title={“Notame”: workflow for non-targeted LC--MS metabolic profiling},
+  author={Kl{\aa}vus, Anton and Kokla, Marietta and Noerman, Stefania and Koistinen, Ville M and Tuomainen, Marjo and Zarei, Iman and Meuronen, Topi and H{\"a}kkinen, Merja R and Rummukainen, Soile and Farizah Babu, Ambrin and others},
+  journal={Metabolites},
+  volume={10},
+  number={4},
+  pages={135},
+  year={2020},
+  publisher={MDPI}
+}
+
+@article{qcguidelines,
+  title={Guidelines and considerations for the use of system suitability and quality control samples in mass spectrometry assays applied in untargeted clinical metabolomic studies},
+  author={Broadhurst, David and Goodacre, Royston and Reinke, Stacey N and Kuligowski, Julia and Wilson, Ian D and Lewis, Matthew R and Dunn, Warwick B},
+  journal={Metabolomics},
+  volume={14},
+  pages={1--17},
+  year={2018},
+  publisher={Springer}
+}
+
+@article{driftcorrection,
+  title={Characterising and correcting batch variation in an automated direct infusion mass spectrometry (DIMS) metabolomics workflow},
+  author={Kirwan, JA and Broadhurst, DI and Davidson, RL and Viant, MR},
+  journal={Analytical and bioanalytical chemistry},
+  volume={405},
+  pages={5147--5157},
+  year={2013},
+  publisher={Springer}
+}
+
+@article{ruvsnormalization,
+  title={Normalization of RNA-seq data using factor analysis of control genes or samples},
+  author={Risso, Davide and Ngai, John and Speed, Terence P and Dudoit, Sandrine},
+  journal={Nature biotechnology},
+  volume={32},
+  number={9},
+  pages={896--902},
+  year={2014},
+  publisher={Nature Publishing Group}
+}
+
+@article{pqn,
+  title={Probabilistic quotient normalization as robust method to account for dilution of complex biological mixtures. Application in 1H NMR metabonomics},
+  author={Dieterle, Frank and Ross, Alfred and Schlotterbeck, G{\"o}tz and Senn, Hans},
+  journal={Analytical chemistry},
+  volume={78},
+  number={13},
+  pages={4281--4290},
+  year={2006},
+  publisher={ACS Publications}
+}
+
+@article{missForest,
+    author = {Stekhoven, Daniel J. and Bühlmann, Peter},
+    title = {MissForest—non-parametric missing value imputation for mixed-type data},
+    journal = {Bioinformatics},
+    volume = {28},
+    number = {1},
+    pages = {112-118},
+    year = {2011},
+    month = {10},
+    issn = {1367-4803},
+    doi = {10.1093/bioinformatics/btr597},
+    url = {https://doi.org/10.1093/bioinformatics/btr597},
+    eprint = {https://academic.oup.com/bioinformatics/article-pdf/28/1/112/50568519/bioinformatics_28_1_112.pdf},
+}


### PR DESCRIPTION
Include additional vignettes for website, namely project_template vignette and notameViz and notameStats vignettes. 

I temporarily allowed website on push to this branch to check that the general idea works, website now includes project_template and vignettes from notameViz and notameStats.

There was talk at some point about including project template vignette, is it really useful @attlih and @RetuWonData ? project_example vignette is quite similar, including project_template.Rmd makes for more maintenance.

Also, on including vignettes from notameStats and notameViz package: I thought I had it figured out but now I don't remember how to include them dynamically :). Manually including the vignettes as articles is an option but not too smooth. The vignettes would be built with the latest Bioc-devel notameStats and notameViz versions, so if there's an error, that would prompt us to copy the vignette anew. Or we skip including vignettes from notameStats and notameViz separately, keep them brief, and perhaps focus on project_example instead? Of course separate websites for notameStats and notameViz is also an option.

