### PR TITLE
Modify assay control

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: notame
 Type: Package
 Title: Workflow for non-targeted LC-MS metabolic profiling
-Version: 1.1.1
+Version: 1.1.2
 Authors@R: c(
     person("Anton", "Klåvus", role = c("aut", "cph"),
            comment = c(ORCID = "0000-0003-2612-0230")),

--- a/R/utils.R
+++ b/R/utils.R
@@ -203,7 +203,6 @@ prop_found <- function(x) {
 }
 
 .get_from_to_names <- function(object, assay.type, name) {
-  object <- as(object, "SummarizedExperiment")
   # Input behavior (from)
   # If assay.type is not supplied and there is only one assay in the objcet, 
   # choose the first assay
@@ -228,7 +227,6 @@ prop_found <- function(x) {
 }
 
 .get_from_name <- function(object, assay.type) {
-  object <- as(object, "SummarizedExperiment")
   # Input behavior (from)
   if (is.null(assay.type) && length(assays(object)) == 1) {
     from <- 1

--- a/R/utils.R
+++ b/R/utils.R
@@ -221,8 +221,6 @@ prop_found <- function(x) {
     to <- 1
   } else if (is.null(name)) {
     stop("When using multiple assays, specify name of new assay", call. = FALSE)
-  } else if (name == from & from != 1) {
-    stop("'name' must be different from `assay.type`.", call. = FALSE)
   } else {
     to <- name
   }

--- a/tests/testthat/test_transformations.R
+++ b/tests/testthat/test_transformations.R
@@ -209,17 +209,13 @@ test_that("Assay control works for transformations (with drift correction)", {
   corrected <- correct_drift(ex_set, name = "corrected")
   # Assay not found with a single unnamed assay
   expect_error(correct_drift(ex_set, assay.type = "original"))
-  # From and to can't have identical names
-  names(assays(ex_set)) <- "original"
-  expect_error(correct_drift(ex_set, 
-    assay.type = "original", name = "original"))
   # Assay not found with multiple assays
   assay(ex_set, "alternative") <- assay(ex_set)
   expect_error(correct_drift(ex_set, 
     assay.type = "nope", name = "corrected"))
   # Only one name can be supplied to assay.type
   expect_error(correct_drift(ex_set,
-    assay.type = c("original", "lel"), name = "corrected"))
+    assay.type = c("original", "nope"), name = "corrected"))
   # Only one name can be supplied to transformed assay
   expect_error(correct_drift(ex_set,
     assay.type = "original", name = c("A", "B")))


### PR DESCRIPTION
Allow overwrite of assay when using multiple assays (without warning). #10

Summary of current behavior:
One can still use a single assay throughout the analysis without specifying `assay.type` and `name`. When using multiple assays, `name` must be specified (because assay control would be complicated for single-assay use if defaults for `name` were supplied in transformations). Overwriting assays is now allowed.